### PR TITLE
changing color default to light, as it fit better with palette green

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -34,7 +34,7 @@ logo: "images/OpenInfra-UserGroup-White.png"
 #  - teal
 #  - yellow
 #color: "dark" # light, dark or auto. Default to auto.
-color: "dark"
+color: "light"
 palettes: []
 palette: "green"
 


### PR DESCRIPTION
dark color breaks the contact form style, so changing to light and in the future color selector needs to disappear.