### PR TITLE
enabling repo info widget / closes #9

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,4 @@
 title: OpenInfra Mexico
 copyright: 'Copyright © 2022-{year} Mexico OpenInfra Community. All Rights Reserved.'
+baseURL: /
+theme: hugo-theme-bootstrap

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -1,10 +1,9 @@
-baseURL: /
-theme: hugo-theme-bootstrap
 paginate: 10
 paginatePath: page
 enableRobotsTXT: true
 enableEmoji: true
 pygmentsUseClasses: true
+enableGitInfo: true
 # googleAnalytics: UA-123-45
 # disqusShortname: yourdiscussshortname
 
@@ -25,5 +24,6 @@ permalinks:
   news: /news/:year/:month/:title/
   blog: /blog/:year/:month/:title/
 
-# module:
-  # proxy: https://goproxy.cn
+security:
+  funcs:
+    getenv: ['^HUGO_', '^CI$', 'PWD']

--- a/layouts/partials/hooks/sidebar-end.html
+++ b/layouts/partials/hooks/sidebar-end.html
@@ -1,0 +1,1 @@
+{{- partial "docs/repo" . }}


### PR DESCRIPTION
Adding request for enable github repo widget.
more info here: https://hbs.razonyang.com/v1/en/docs/widgets/repository/